### PR TITLE
docs: clarify issue assignment rule fix #2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Para manter o projeto organizado e justo para todos, pedimos que siga os passos 
 
 1.  Vá para a nossa [lista de Issues](https://github.com/adalbertobrant/secretgamenumber/issues).
 2.  Use as etiquetas (`labels`) para filtrar, como `bug`, `feature`, `documentation`, `good first issue`, etc.
-3.  Escolha uma issue que ainda não tenha sido atribuída a ninguém.
+3.  Escolha uma issue que ainda não tenha sido designada a ninguém.
 4.  **Comente na issue** que você gostaria de trabalhar nela (ex: `"Olá! Gostaria de trabalhar nesta issue."`).
 5.  Aguarde que um mantenedor atribua a issue a você. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Para manter o projeto organizado e justo para todos, pedimos que siga os passos 
 
 1.  Vá para a nossa [lista de Issues](https://github.com/adalbertobrant/secretgamenumber/issues).
 2.  Use as etiquetas (`labels`) para filtrar, como `bug`, `feature`, `documentation`, `good first issue`, etc.
-3.  Escolha uma issue, cada issue pode ser designada para até 10 pessoas, não se preocupe se outra pessoa estiver fazendo faça também.
+3.  Escolha uma issue que ainda não tenha sido atribuída a ninguém.
 4.  **Comente na issue** que você gostaria de trabalhar nela (ex: `"Olá! Gostaria de trabalhar nesta issue."`).
 5.  Aguarde que um mantenedor atribua a issue a você. 
 


### PR DESCRIPTION
This PR updates Step 1, Item 3 in CONTRIBUTING.md to remove ambiguity in the issue assignment process.

- Removed the statement that up to 10 people can be assigned to the same issue  
- Replaced with clearer text: "Escolha uma issue que ainda não tenha sido designada a ninguém."  

Closes #2
