### PR TITLE
Docs: Update standardize branch naming rule in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Para manter o projeto organizado e justo para todos, pedimos que siga os passos 
     > ⚠️ **Regra Especial para Tutoriais de Deploy:** Se você estiver trabalhando em uma issue de tutorial de deploy, a branch **deve** ter o seu nome de usuário do GitHub.
     >
     > ```bash
-    > git checkout -b seu-nome-de-usuario-github-tutorial-issueNumber
+    > git checkout -b seu-nome-de-usuario-github
     > ```
 
 2.  Faça as alterações necessárias no código para resolver a issue.


### PR DESCRIPTION
Closes #5

Hi there! I've updated the branch naming rule in the `CONTRIBUTING.md` file to follow the explicit instructions in the issue's "Action Plan".

As per the issue, I have changed the code example to `git checkout -b seu-nome-de-usuario-github`.

I noticed the `README.md` file still has a different format. This PR makes the change requested in this issue, and a separate issue could be created to align the `README.md` if needed.

Thank you!