### PR TITLE
feat: allow submitting guess with Enter key when input field is focused

### DIFF
--- a/app.js
+++ b/app.js
@@ -144,13 +144,20 @@ window.onclick = function (event) {
 }
 // Listen for any key press on the whole page
 document.addEventListener('keydown', function(event) {
-  
-  const restartButton = document.getElementById('reiniciar');
-  if (event.key === 'Enter' && !restartButton.disabled) {
-    
-    reiniciarJogo();
+  if (event.key === 'Enter') {
+    const restartButton = document.getElementById('reiniciar');
+    const inputField = document.querySelector('input');
+
+    // If the restart button is enabled → restart the game
+    if (!restartButton.disabled) {
+      reiniciarJogo();
+    } 
+    // Otherwise, if input has focus make a guess
+    else if (document.activeElement === inputField) {
+      verificarChute();
+    }
   }
-})
+});
 
 // --- Parallax Effect Logic ---
 document.addEventListener('mousemove', function(e) {


### PR DESCRIPTION
## Description
This PR adds support for submitting a guess when the user presses the **Enter** key while the input field is focused.  
Previously, guesses could only be submitted by clicking the **"Guess"** button.  
This small UX improvement makes the gameplay smoother and more intuitive.

## Changes Made
- Added a `keydown` event listener that:
  - Calls `verificarChute()` when Enter is pressed and the input field is focused.
  - Keeps existing behavior to restart the game with Enter when the "Restart" button is enabled.
- Ensured both behaviors coexist without conflict.

## Motivation
Many players instinctively press **Enter** after typing a number.  
This change improves accessibility and enhances the user experience without altering existing game logic.

## Testing
- Verified that:
  - Enter triggers a guess only when the input is focused.
  - Enter restarts the game only when the restart button is active.
  - No other keys affect gameplay.

## Additional Notes
No breaking changes.  
Tested on latest versions of Chrome and Firefox.
